### PR TITLE
Update WindsorBootstrapper.cs

### DIFF
--- a/src/Desktop/PrismContrib.WindsorExtensions/WindsorBootstrapper.cs
+++ b/src/Desktop/PrismContrib.WindsorExtensions/WindsorBootstrapper.cs
@@ -87,15 +87,32 @@ namespace PrismContrib.WindsorExtensions
             this.Shell = this.CreateShell();
             if (this.Shell != null)
             {
-                this.Logger.Log(Resources.SettingTheRegionManager, Category.Debug, Priority.Low);
-                RegionManager.SetRegionManager(this.Shell, this.Container.Resolve<IRegionManager>());
+                    if (this.Shell.Dispatcher.Thread == Thread.CurrentThread)
+                    {
+                        this.Logger.Log(Resources.SettingTheRegionManager, Category.Debug, Priority.Low);
+                        RegionManager.SetRegionManager(this.Shell, this.Container.Resolve<IRegionManager>());
 
-                this.Logger.Log(Resources.UpdatingRegions, Category.Debug, Priority.Low);
-                RegionManager.UpdateRegions();
 
-                this.Logger.Log(Resources.InitializingShell, Category.Debug, Priority.Low);
-                this.InitializeShell();
-            }
+                        this.Logger.Log(Resources.UpdatingRegions, Category.Debug, Priority.Low);
+                        RegionManager.UpdateRegions();
+
+
+                        this.Logger.Log(Resources.InitializingShell, Category.Debug, Priority.Low);
+                        this.InitializeShell();
+                    }
+                    else this.Shell.Dispatcher.Invoke((Action)delegate()
+                    {
+                        this.Logger.Log(Resources.SettingTheRegionManager, Category.Debug, Priority.Low);
+                        RegionManager.SetRegionManager(this.Shell, this.Container.Resolve<IRegionManager>());
+
+
+                        this.Logger.Log(Resources.UpdatingRegions, Category.Debug, Priority.Low);
+                        RegionManager.UpdateRegions();
+
+
+                        this.Logger.Log(Resources.InitializingShell, Category.Debug, Priority.Low);
+                        this.InitializeShell();
+                    });            }
 
             this.Logger.Log(Resources.InitializingModules, Category.Debug, Priority.Low);
             this.InitializeModules();


### PR DESCRIPTION
This change makes the WindsorBootstrapper.Run available from a background thread giving the ability to show interactive splashscreen.

When overridden, the background bootstrap process seems to be something like the following:

        public override sealed void Run(bool runWithDefaultConfiguration)
        {
            _dispatcher = Dispatcher.FromThread(Thread.CurrentThread);
            _run = new BackgroundWorker();
            _run.DoWork += _run_DoWork;
            _run.RunWorkerAsync(runWithDefaultConfiguration);
        }

        private void _run_DoWork(object sender, DoWorkEventArgs e)
        {
            Run_Async((bool)e.Argument);
        }


        protected virtual void Run_Async(bool runWithDefaultConfiguration)
        {
            ShowSplash();
            try
            {
base.Run(runWithDefaultConfiguration);
SwitchToShell();
}
            catch (Exception ex)
            {
                _logger.InnerLogger.Fatal("Bla-bla-bla", ex);
                _splash.Close();
            }
}